### PR TITLE
Add note about build dir with spaces on Windows

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -108,6 +108,8 @@ Start by installing and setting up [MSYS2](https://www.msys2.org/).
 !!! important
     After installing MSYS2, you'll need to open **MSYS2 MinGW 64-bit** to
     perform building. Otherwise, you may see build failures for cc.exe.
+    Please make sure to not have any whitesspace in your build path or it will cause build errors.
+    E.g: `C:\Users\User Name\xqemu\build.sh` will not work.
 
 Once MSYS2 has been installed, install all of the necessary packages by running:
 
@@ -194,6 +196,8 @@ development!) You can launch with the following command:
         -drive index=0,media=disk,file=$HDD,locked \
         -drive index=1,media=cdrom,file=$DISC \
         -usb -device usb-xbox-gamepad
+
+Note: If launching a pre-built binary from AppVeyor, replace `./i386-softmmu/qemu-system-i386` with `./xqemu`
 
 Of course, on Windows the executable path will have a `.exe` extension.
 


### PR DESCRIPTION
This commit adds a little note about spaces & `build.sh` on Windows.
The build script does not run if your build directory has spaces in it.