### PR TITLE
Update OpenVPN TAP Driver link

### DIFF
--- a/docs/networking.md
+++ b/docs/networking.md
@@ -19,7 +19,7 @@ documentation](https://wiki.qemu.org/Documentation/Networking).
 ## Windows
 
 __Requirements__
-- [OpenVPN TAP Driver](https://openvpn.net/index.php/open-source/downloads.html) (Scroll down to “Tap-Windows”)
+- [OpenVPN TAP Driver](https://build.openvpn.net/downloads/releases/latest/) (Download “Tap-Windows”)
 
 Install the prerequisites then you’ll need to manually bridge your main adapter and the newly created TAP adapter. This is easily done by going to `Network & Sharing Center` then `Change adapter settings`.
 


### PR DESCRIPTION
Sometime ago OpenVPN changes their download page layout and removed the ability to easily download just the TAP driver. This commit updates that link to a page will all files from their latest build.