### PR TITLE
Hide github icon unless on developer page

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,8 @@ copyright: 'Copyright &copy; 2018-2019 XQEMU Developers'
 # Configuration
 theme:
   name: material
+  custom_dir: theme_overrides
+
   palette:
     primary: green
     accent: light green
@@ -57,6 +59,8 @@ theme:
     code: Roboto Mono
   logo:
     icon: "games"
+
+developer_route: developers
 
 # Extensions
 markdown_extensions:

--- a/theme_overrides/partials/header.html
+++ b/theme_overrides/partials/header.html
@@ -1,0 +1,91 @@
+<!--
+  Copyright (c) 2016-2019 Martin Donath <martin.donath@squidfunk.com>
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to
+  deal in the Software without restriction, including without limitation the
+  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+  sell copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+  IN THE SOFTWARE.
+-->
+
+<!-- Application header -->
+<header class="md-header" data-md-component="header">
+
+  <!-- Top-level navigation -->
+  <nav class="md-header-nav md-grid">
+    <div class="md-flex">
+
+      <!-- Link to home -->
+      <div class="md-flex__cell md-flex__cell--shrink">
+        <a href="{{ config.site_url | default(nav.homepage.url, true) | url }}"
+            title="{{ config.site_name }}"
+            class="md-header-nav__button md-logo">
+          {%- if config.theme.logo.icon -%}
+            <i class="md-icon">{{- config.theme.logo.icon -}}</i>
+          {%- else -%}
+            <img src="{{ config.theme.logo | url }}" width="24" height="24" />
+          {%- endif -%}
+        </a>
+      </div>
+
+      <!-- Button to toggle drawer -->
+      <div class="md-flex__cell md-flex__cell--shrink">
+        <label class="md-icon md-icon--menu md-header-nav__button"
+            for="__drawer"></label>
+      </div>
+
+      <!-- Header title -->
+      <div class="md-flex__cell md-flex__cell--stretch">
+        <div class="md-flex__ellipsis md-header-nav__title"
+            data-md-component="title">
+          {%- if config.site_name == page.title -%}
+            {{ config.site_name }}
+          {%- else -%}
+            <span class="md-header-nav__topic">
+              {{- config.site_name -}}
+            </span>
+            <span class="md-header-nav__topic">
+              {%- if page and page.meta and page.meta.title -%}
+                {{- page.meta.title -}}
+              {%- else -%}
+                {{- page.title -}}
+              {%- endif -%}
+            </span>
+          {%- endif -%}
+        </div>
+      </div>
+
+      <!-- Button to open search dialogue -->
+      <div class="md-flex__cell md-flex__cell--shrink">
+        {%- if "search" in config["plugins"] -%}
+          <label class="md-icon md-icon--search md-header-nav__button"
+              for="__search"></label>
+
+          <!-- Search interface -->
+          {%- include "partials/search.html" -%}
+        {%- endif -%}
+      </div>
+
+      <!-- Repository containing source -->
+      {%- if config.repo_url and config.developer_route in page.url -%}
+        <div class="md-flex__cell md-flex__cell--shrink">
+          <div class="md-header-nav__source">
+            {%- include "partials/source.html" -%}
+          </div>
+        </div>
+      {%- endif -%}
+    </div>
+  </nav>
+</header>

--- a/theme_overrides/partials/nav.html
+++ b/theme_overrides/partials/nav.html
@@ -1,0 +1,54 @@
+<!--
+  Copyright (c) 2016-2019 Martin Donath <martin.donath@squidfunk.com>
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to
+  deal in the Software without restriction, including without limitation the
+  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+  sell copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+  IN THE SOFTWARE.
+-->
+
+<!-- Main navigation -->
+<nav class="md-nav md-nav--primary" data-md-level="0">
+
+    <!-- Site title -->
+    <label class="md-nav__title md-nav__title--site" for="__drawer">
+      <a href="{{ config.site_url | default(nav.homepage.url, true) | url }}"
+          title="{{ config.site_name }}" class="md-nav__button md-logo">
+        {%- if config.theme.logo.icon -%}
+          <i class="md-icon">{{- config.theme.logo.icon -}}</i>
+        {%- else -%}
+          <img src="{{ config.theme.logo | url }}" width="48" height="48" />
+        {%- endif -%}
+      </a>
+      {{- config.site_name -}}
+    </label>
+
+    <!-- Repository containing source -->
+    {%- if config.repo_url and config.developer_route in page.url -%}
+      <div class="md-nav__source">
+        {%- include "partials/source.html" -%}
+      </div>
+    {%- endif -%}
+
+    <!-- Render item list -->
+    <ul class="md-nav__list" data-md-scrollfix>
+      {%- for nav_item in nav -%}
+        {%- set path = "nav-" + loop.index | string -%}
+        {%- set level = 1 -%}
+        {%- include "partials/nav-item.html" -%}
+      {%- endfor -%}
+    </ul>
+  </nav>


### PR DESCRIPTION
Closes #39 

### Option 1 (this pr)
Overrides to the existing partials so that the github icon is not shown on any pages other than the developer pages.

I like that this implementation keeps the conditional display of the github icon in the templates, statically rendering to html.

I don't like how much code needs to be repeated:
- partials are just copy + pastes from https://github.com/squidfunk/mkdocs-material/tree/master/src/partials
- repeated conditional in both nav and header
- exposed config option to set the "whitelisted" route. Kinda feels dirty though.

### Option 2
I also have an alternative implementation done with JS + CSS: https://github.com/DiscoStarslayer/xqemu.com/pull/1/files

I feel the intent of the code is clearer on the JS implementation, but I am not a big fan of the fact that it has to run in the browser instead of just being a statically rendered element.

### Option 3
Just remove this icon all-together to avoid the added complexity. One line of CSS + a config change to `mkdocs.yml` will do this pretty cleanly.

