### PR TITLE
Use CI badges for master and specific platform

### DIFF
--- a/docs/developers/index.md
+++ b/docs/developers/index.md
@@ -23,9 +23,9 @@ This project is hosted on GitHub at [github.com/xqemu/xqemu](https://github.com/
 
 Build Status
 ------------
-| Windows | Linux | macOS |
+| Windows | macOS | Linux |
 | ------- | ----- | ----- |
-| [![Build status](https://ci.appveyor.com/api/projects/status/i1m0keigjabxg170/branch/master?svg=true)](https://ci.appveyor.com/project/xqemu-bot/xqemu) | [![Travis-CI Status](https://travis-ci.org/xqemu/xqemu.svg?branch=master)](https://travis-ci.org/xqemu/xqemu) | [![Travis-CI Status](https://travis-ci.org/xqemu/xqemu.svg?branch=master)](https://travis-ci.org/xqemu/xqemu) |
+| [![Build status](https://ci.appveyor.com/api/projects/status/i1m0keigjabxg170/branch/master?svg=true)](https://ci.appveyor.com/project/xqemu-bot/xqemu) | [![Travis-CI Status](https://travis-matrix-badges.herokuapp.com/repos/xqemu/xqemu/branches/master/2)](https://travis-ci.org/xqemu/xqemu) | [![Travis-CI Status](https://travis-matrix-badges.herokuapp.com/repos/xqemu/xqemu/branches/master/1)](https://travis-ci.org/xqemu/xqemu) |
 
 Building From Source Code
 --------------------


### PR DESCRIPTION
Taking over #45 by copying from xqemu/xqemu, as it also fixes some other problems.

Closes #44 