### PR TITLE
Add `coreutils` to build requirements on macOS

### DIFF
--- a/docs/developers/building.md
+++ b/docs/developers/building.md
@@ -66,7 +66,7 @@ First make sure you've installed the [Homebrew](https://brew.sh/) package
 manager, then update and install necessary packages:
 
     brew update
-    brew install libffi gettext glib pixman pkg-config autoconf pixman sdl2 libepoxy
+    brew install libffi gettext glib pixman pkg-config autoconf pixman sdl2 libepoxy coreutils
 
 Clone the repo:
 


### PR DESCRIPTION
Now that https://github.com/xqemu/xqemu/pull/265 is merged, macOS requires `coreutils` to build properly.

Just updating the docs to align with this change.