### PR TITLE
input: Move udev rules comments to separate lines

### DIFF
--- a/docs/input.md
+++ b/docs/input.md
@@ -93,8 +93,13 @@ On Linux you can use `lsusb` for step 2. Step 3 involves adding a udev rule on
 most linux distributions. The udev rule (/etc/udev/rules.d/999-xbox-
 gamepad.rules) for a Controller-S could look like this:
 
-	SUBSYSTEMS=="usb", ATTRS{idVendor}=="045e", ATTRS{idProduct}=="0288", GROUP="users", MODE="660" # Hub
-	SUBSYSTEMS=="usb", ATTRS{idVendor}=="045e", ATTRS{idProduct}=="0289", GROUP="users", MODE="660" # Gamepad
+	# Duke (Hub; Gamepad)
+	SUBSYSTEMS=="usb", ATTRS{idVendor}=="045e", ATTRS{idProduct}=="001c", GROUP="users", MODE="660"
+	SUBSYSTEMS=="usb", ATTRS{idVendor}=="045e", ATTRS{idProduct}=="0202", GROUP="users", MODE="660"
+
+	# Controller S (Hub; Gamepad)
+	SUBSYSTEMS=="usb", ATTRS{idVendor}=="045e", ATTRS{idProduct}=="0288", GROUP="users", MODE="660"
+	SUBSYSTEMS=="usb", ATTRS{idVendor}=="045e", ATTRS{idProduct}=="0289", GROUP="users", MODE="660"
 
 #### Hub-Forwarding
 


### PR DESCRIPTION
Current build of `udev` in Debian Testing (243-9) doesn't handle comments the same way as before - they need a line of their own to be respected and not parsed as an argument.
As the comment texts are not considered valid key/value pairs `udev` fails to parse them and ignores the rules.
Even if this might be considered a bug in the Debian build the XQEMU docs wouldn't hurt from respecting this behavior.