### PR TITLE
Update CI URLs

### DIFF
--- a/docs/developers/index.md
+++ b/docs/developers/index.md
@@ -23,9 +23,11 @@ This project is hosted on GitHub at [github.com/xqemu/xqemu](https://github.com/
 
 Build Status
 ------------
-| Windows | macOS | Linux |
-| ------- | ----- | ----- |
-| [![Build status](https://ci.appveyor.com/api/projects/status/i1m0keigjabxg170/branch/master?svg=true)](https://ci.appveyor.com/project/xqemu-bot/xqemu) | [![Travis-CI Status](https://travis-matrix-badges.herokuapp.com/repos/xqemu/xqemu/branches/master/2)](https://travis-ci.org/xqemu/xqemu) | [![Travis-CI Status](https://travis-matrix-badges.herokuapp.com/repos/xqemu/xqemu/branches/master/1)](https://travis-ci.org/xqemu/xqemu) |
+| Platform | Build Status |
+|----------|--------------|
+| Windows | [![Build status](https://github.com/xqemu/xqemu/workflows/Build%20(Windows)/badge.svg?branch=master)](https://github.com/xqemu/xqemu/actions?query=branch%3Amaster) |
+| macOS | [![Build status](https://github.com/xqemu/xqemu/workflows/Build%20(macOS)/badge.svg?branch=master)](https://github.com/xqemu/xqemu/actions?query=branch%3Amaster) |
+| Ubuntu | [![Build status](https://github.com/xqemu/xqemu/workflows/Build%20(Ubuntu)/badge.svg?branch=master)](https://github.com/xqemu/xqemu/actions?query=branch%3Amaster) |
 
 Building From Source Code
 --------------------

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,6 @@
 Getting XQEMU
 -------------
-**Download for Windows:** The latest, pre-built release version of XQEMU for Windows can be [**downloaded here**](https://ci.appveyor.com/api/projects/xqemu-bot/xqemu/artifacts/xqemu.zip?branch=master&job=Environment:%20MSYS2_ARCH=x86_64,%20MSYSTEM=MINGW64;%20Configuration:%20Release&pr=false).
+**Download for Windows:** The latest, pre-built release version of XQEMU for Windows can be [**downloaded here**](https://github.com/xqemu/xqemu/suites/373368695/artifacts/830137).
 
 Linux and macOS users will need to build XQEMU from source, see [Building XQEMU from Source](developers/building.md).
 
@@ -117,7 +117,7 @@ You can launch with the following command:
         -usb -device usb-xbox-gamepad
 
 Of course, on Windows the executable path will have a `.exe` extension. If launching
-a pre-built binary from AppVeyor, replace `./i386-softmmu/qemu-system-i386` with
+a pre-built binary, replace `./i386-softmmu/qemu-system-i386` with
 `xqemu.exe`.
 
 Replace the variables `$MCPX`, `$BIOS`, `$HDD`, and `$DISC` with the appropriate

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,7 +87,7 @@ markdown_extensions:
   - pymdownx.tilde
 
 # Page tree
-pages:
+nav:
   - Welcome: index.md
   - Screenshots: screenshots.md
   - Getting Started: getting-started.md


### PR DESCRIPTION
Comments about the 3 commits:

- CI build status was taken from XQEMU README.md
- Download URL was manually fetched from Actions tab (https://github.com/xqemu/xqemu/runs/362738213)
- `mkdocs serve` warned: `WARNING -  Config value: 'pages'. Warning: The 'pages' configuration option has been deprecated and will be removed in a future release of MkDocs. Use 'nav' instead.`

Will self-merge in the next days if there isn't a veto (or it wasn't merged by then).